### PR TITLE
update requirements with url to pyrnvapi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask
 multi_key_dict
-pyrnvapi >= 0.2
+https://github.com/MyRNVPlan/pyrnvapi/archive/v0.2.zip#egg=pyrnvapi


### PR DESCRIPTION
See https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support for other possibilities to directly include a git repo as python package.