### PR TITLE
hotfix for stations with a / in their name

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import threading
 import time
 import sys
 import os
+import re
 
 import pyrnvapi
 
@@ -158,6 +159,8 @@ def get_called_stations(path):
     laststation = ""
     stations = {}
     for item in path.split('/'):
+        item = re.sub(r"\+\+", r"/", item)
+
         if item == "" or item.isdigit():
             continue
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
         <table border="1" cellspacing="10">
             <tr><td><b>Haltestelle</b></td><td><b>Kürzel</b></td></tr>
             {% for key,value in stations.items() %}
-            <tr><td><a href="{{value}}">{{value}}</a></td><td><a href="{{key}}">{{key}}</a></td></tr>
+            <tr><td><a href="{{value|urlencode|replace("/", "++")}}">{{value}}</a></td><td><a href="{{key}}">{{key}}</a></td></tr>
             {% endfor %}
         </table>
         </div>


### PR DESCRIPTION
Currently it's not possible to click on stations with a `/` in their name, like most of the S-Bahn stations. The current hack replaces `/` with `++` that they won't be splitted in https://github.com/joker234/MyRNVPlan/commit/d812310849ea3c2473237e4b1aab59508f1b6820#diff-5bc02cefb3ea9e27f1a6776eabd1935dR161.

Better suggestions welcome :)